### PR TITLE
Re-enable macos tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install gfortran
     - name: Symlink gfortran for MacOS
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-10.15'
       run: ln -s /usr/local/bin/gfortran-9 /usr/local/bin/gfortran
     - name: Check gfortran version
       run: gfortran --version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest,]
+        os: [ubuntu-latest,macos-10.15]
         python-version: [3.7,]
 
     steps:
@@ -28,6 +28,9 @@ jobs:
     - name: Install gfortran for Linux
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install gfortran
+    - name: Symlink gfortran for MacOS
+      if: matrix.os == 'macos-latest'
+      run: ln -s /usr/local/bin/gfortran-9 /usr/local/bin/gfortran
     - name: Check gfortran version
       run: gfortran --version
     - name: Install package


### PR DESCRIPTION
Added a step to symlink gfortran-9 on macos as newer macos containers do not have the symlink by default.