### PR TITLE
polished plots and fixed wrong TTC time vector in pyxpcs

### DIFF
--- a/Xana/SaxsAna/defineqrois.py
+++ b/Xana/SaxsAna/defineqrois.py
@@ -72,7 +72,7 @@ def flatten_init(inp):
         i += 1
     return rois
 
-def defineqrois(setup, Isaxs, qv_init=None, phiv_init=[(0,360)], 
+def defineqrois(setup, Isaxs, qv_init=None, phiv_init=[(0,360)],
                 plot=False, d=250, mirror=False, **kwargs):
 
     # check_dimension(setup, Isaxs)
@@ -97,7 +97,7 @@ def defineqrois(setup, Isaxs, qv_init=None, phiv_init=[(0,360)],
 
     setup.dqv = qv_init[:,1]
     setup.phiv = phiv_init
-    setup.qv = np.tile(qv_init[:,0],setup.phiv.shape[0])
+    setup.qv = np.repeat(qv_init[:,0],setup.phiv.shape[0])
     setup.radii = radii
 
     setup.gproi = np.array([len(x[0]) for x in qroi], dtype=int)

--- a/Xana/XParam/parameters.py
+++ b/Xana/XParam/parameters.py
@@ -80,7 +80,7 @@ def plot_parameters(pars, parameter, R=250e-9, T=22, fit=None, modes=1, ax=None,
     else:
         dofit = True
 
-    qv = pars['q']
+    qv = np.array(pars['q'])
     qv = qv**alpha
 
     # values to be excluded
@@ -144,8 +144,8 @@ def plot_parameters(pars, parameter, R=250e-9, T=22, fit=None, modes=1, ax=None,
                 # ax[0].plot(x2,m_ls*x2+b_ls)
                 m, b = [(x[0], np.mean(x[1:])) for x in (m, b)]
             else:
-                res = fit_basic(qv[iif], y[iif], dy[iif],
-                                fit, dict(init), fix, emcee)
+                res = fit_basic(qv[iif], y[iif], dy[iif], fit, init=dict(init),
+                        fix=fix, emcee=emcee, **kwargs)
                 fitpar = res[0].astype(np.float32)
                 yf = res[4].eval(res[2].params, x=x)
 

--- a/Xana/Xfit/fit_basic.py
+++ b/Xana/Xfit/fit_basic.py
@@ -30,9 +30,9 @@ def residual(pars, x, func, data=None, eps=None):
     model = func.eval(pars, x=x)
 
     if eps is not None:
-        resid = np.sqrt((data - model)**2 * eps**2)
+        resid = (data - model)* eps
     else:
-        resid = np.abs(data - model)
+        resid = data - model
     return resid
 
 def lnlike(pars, x, func, data=None, eps=None):
@@ -96,8 +96,10 @@ def quadratic(x, a, b, c):
 def exponential(x, a, t, b, g):
     return a*np.exp(-(x/t)**g) + b
 
+
 # Main Fit Function
-def fit_basic( x, y, dy=None, model='line', init={}, fix=None, emcee=False, plot_corner=False):
+def fit_basic( x, y, dy=None, model='line', init={}, fix=None, method='leastsq',
+        emcee=False, plot_corner=False, **kwargs):
 
     if model in 'linear':
         func = linear
@@ -138,7 +140,8 @@ def fit_basic( x, y, dy=None, model='line', init={}, fix=None, emcee=False, plot
             corner.corner(out.flatchain, labels=out.var_names, truths=list(out.params.valuesdict().values()))
 
     else:
-        out = lmfit.minimize(residual, pars, args=(x, model), kws={'data':y, 'eps':wgt}, nan_policy='omit')
+        out = lmfit.minimize(residual, pars, args=(x, model), method=method,
+                kws={'data':y, 'eps':wgt}, nan_policy='omit', **kwargs)
         fit_report = lmfit.fit_report(out)
 
     pars_arr =  np.zeros((len(pars),2))

--- a/Xana/XpcsAna/CorrFunc.py
+++ b/Xana/XpcsAna/CorrFunc.py
@@ -561,7 +561,7 @@ class CorrFunc(AnaList):
                        vmin=vmin, vmax=vmax)
         ax.set_xlabel(r'$t_1$ [s]',)
         ax.set_ylabel(r'$t_2$ [s]',)
-        cl = plt.colorbar(im, ax=ax)
+        cl = plt.colorbar(im, ax=ax, shrink=.5)
         cl.ax.set_ylabel('correlation', fontsize=12)
         # niceplot(ax, autoscale=False, grid=False)
 
@@ -596,7 +596,7 @@ class CorrFunc(AnaList):
         if 'y' in log:
             ax.set_yscale('log')
 
-        plt.legend()
+        # plt.legend()
 
         # ax.set_title('trace', fontweight='bold', fontsize=14, y=1.14)
 

--- a/Xana/XpcsAna/eventcorrelator3.py
+++ b/Xana/XpcsAna/eventcorrelator3.py
@@ -34,6 +34,9 @@ def eventcorrelator(data, qroi, qv=None, dt=1., method='matrix',
         elif method == 'events':
             npix = qroi[roii][0].size
             pix, t, s = data[roii]
+            pix = pix.astype('int32')
+            t = t.astype('int32')
+            s = s.astype('int32')
             ntimes = s.size
 
         # initialize variables

--- a/Xana/XpcsAna/pyxpcs3.py
+++ b/Xana/XpcsAna/pyxpcs3.py
@@ -389,7 +389,10 @@ def pyxpcs(data, qroi=None, dt=1., qv=None, saxs=None, mask=None, ctr=(0, 0),
 
     # time axis of twotime correlation function
     if equally_spaced:
-        tt_vec = np.linspace(0, nf, tt_max_images)*dt
+        if nf > tt_max_images:
+            tt_vec = np.linspace(0, nf, tt_max_images)*dt
+        else:
+            tt_vec = np.arange(nf) * dt
     else:
         tt_vec = tvec.copy()
 


### PR DESCRIPTION
- the XPCS trace intensity plot does not show  the legend anymore
- the time axis of the TwoTime - correlation function was wrong when rebinning the TTC.
- added `method` option to fit_basic such that the `lmfit` minimization algorithm can be passed.