### PR TITLE
Create python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Since the repository is owned by you I can't modify the secrets. You'll need to add a secret called `PYPI_USERNAME` set to `__token__`, then on pypi you can click "manage" on the package, then "settings", then "create a token", and save that token as the `PYPI_PASSWORD` secret.

This workflow runs whenever you make a new release.

You'll have to bump the version number each time before new releases since PyPI (sensibly) doesn't let you release the same version multiple times.

You said you built and uploaded the package manually before, are these steps (`setup.py sdist bdist_wheel`, then `twine upload dist/*`) enough, or are there some additional build steps needed?