### PR TITLE
Multi target wheel

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* pp27-*"  # skip Python 2.7 wheels
+          CIBW_SKIP: "cp27-* pp27-* cp35-* cp36-* pp36* cp37-* pp37-*"  # skip wheels
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
         build-requirements: 'cython numpy'
 
     - name: Build and publish

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,12 +18,18 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine numpy cython
+
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m'
+        build-requirements: 'cython numpy'
 
     - name: Build and publish
       env:
@@ -31,4 +37,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload dist/*-manylinux*.whl

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,40 +1,57 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package
+name: Upload Python Package to PyPi
 
-on:
-  release:
-    types: [created]
+# on:
+#   release:
+#     types: [created]
+    
+on: [push, pull_request] # for testing
 
 jobs:
-  deploy:
-
-    runs-on: ubuntu-latest
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine numpy cython
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine numpy cython
+          
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.7.1
 
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
-      with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
-        build-requirements: 'cython numpy'
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "cp27-* pp27-*"  # skip Python 2.7 wheels
 
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*-manylinux*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+#     - name: Build manylinux Python wheels
+#       uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+#       with:
+#         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+#         build-requirements: 'cython numpy'
+
+#     - name: Build and publish
+#       env:
+#         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#       run: |
+#         python setup.py sdist bdist_wheel
+#         twine upload dist/*-manylinux*.whl

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,11 +3,11 @@
 
 name: Upload Python Package to PyPi
 
-# on:
-#   release:
-#     types: [created]
+on:
+  release:
+    types: [created]
     
-on: [push, pull_request] # for testing
+# on: [push, pull_request] # for testing
 
 jobs:
   build_wheels:
@@ -42,16 +42,9 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-#     - name: Build manylinux Python wheels
-#       uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
-#       with:
-#         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
-#         build-requirements: 'cython numpy'
-
-#     - name: Build and publish
-#       env:
-#         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-#         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-#       run: |
-#         python setup.py sdist bdist_wheel
-#         twine upload dist/*-manylinux*.whl
+      - name: Publish to PiPy
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload wheelhouse/*.whl


### PR DESCRIPTION
Looked around a bit and found this action: https://github.com/marketplace/actions/python-wheels-manylinux-build

It uses a docker container to build make wheels for multiple versions of python and linux, and at the end uploads them all to pypi with twine. I'm not too sure if this will work, but it's worth a go.