### PR TITLE
pyxpcs can handle 1D data

### DIFF
--- a/Xana/XpcsAna/pyxpcs3.py
+++ b/Xana/XpcsAna/pyxpcs3.py
@@ -260,13 +260,12 @@ def pyxpcs(
 
     time0 = time()
 
-    # q-bins
-    lqv = len(qroi)
-    rlqv = range(lqv)
-    if qv is None:
-        qv = np.arange(lqv)
-
     if isinstance(data, np.ndarray):
+        if data.ndim == 1:
+            # handling 1D data
+            data = data.reshape(-1, 1, 1)
+            qroi = [(np.array([0]), np.array([0])),]
+
         nf, *dim = np.shape(data)
 
         def get_chunk():
@@ -282,6 +281,12 @@ def pyxpcs(
 
     else:
         raise ValueError(f"Cannot process data of type {type(data)}")
+
+    # q-bins
+    lqv = len(qroi)
+    rlqv = range(lqv)
+    if qv is None:
+        qv = np.arange(lqv)
 
     # check time spacing
     if isinstance(dt, (float, int)) and not isinstance(time_spacing, Iterable):


### PR DESCRIPTION
PyXPCS was developed for 2D input data from pixelated detectors. We added an option to handle also 1D data, for instance, from a diode. Please note that:
- a list of ROIs does not have to be provided in this case,
- the normalization has to be chosen carefully as normalization schemes based on the standard deviation do not work in the 1D case.